### PR TITLE
Fixed Null Liquids

### DIFF
--- a/src/main/java/us/timinc/randommachines/recipes/outputs/FluidStackOutput.java
+++ b/src/main/java/us/timinc/randommachines/recipes/outputs/FluidStackOutput.java
@@ -9,6 +9,9 @@ public class FluidStackOutput extends Output<FluidStack> {
 
   @Override
   public FluidStack create() {
+    if (amount == 0) {
+      return null;
+    }
     FluidStack createdFluidStack = new FluidStack(FluidRegistry.getFluid(name), amount);
     return createdFluidStack;
   }


### PR DESCRIPTION
Recipes without liquid outputs were causing errors. Fixed that by returning null instead of a liquid with a blank name and 0 quantity. I'm leaving the error that will occur if someone tries to have a quantity higher than 0 paired with a name that is incorrect, as that should give the user some feedback about the issue.